### PR TITLE
using port report by node instead of from config

### DIFF
--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -162,7 +162,7 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 					finished:                    false,
 					inKubemark:                  false,
 					resourceDataGatheringPeriod: resourceDataGatheringPeriod,
-					port:                        port,
+					port:                        int(node.Status.DaemonEndpoints.KubeletEndpoint.Port)
 				})
 			}
 		}


### PR DESCRIPTION
in some cases, kubemark may use different ports, the origin code uses static port, which can not connect some kubemark daemons